### PR TITLE
Change 'get_model' to use the mlflowclient instead of a web request.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         'numpy',
         'pandas',
         'pyyaml',
-        'requests',
         'scikit-learn',
 
         'python-box',

--- a/src/myautoml/utils/mlflow/tracking.py
+++ b/src/myautoml/utils/mlflow/tracking.py
@@ -2,7 +2,6 @@ import importlib
 import logging
 from pathlib import Path
 import pickle
-import requests
 import tempfile
 from yaml import safe_load
 
@@ -18,8 +17,9 @@ _logger = logging.getLogger(__name__)
 def get_model(run_id: str,
               model_path: str = "model"):
     # Determine how to load the model
-    ml_model_url = f"{mlflow.get_tracking_uri()}/get-artifact?path={model_path}%2FMLmodel&run_id={run_id}"
-    ml_model = safe_load(requests.get(ml_model_url).content)
+    artifact_uri = mlflow.get_run(run_id).info.artifact_uri
+    ml_model_url = Path(artifact_uri, model_path, "MLmodel").as_posix()
+    ml_model = safe_load(mlflow.artifacts.load_text(ml_model_url))
     loader_module = ml_model["flavors"]["python_function"]["loader_module"]
     _logger.debug(f"Loader module for the model: {loader_module}")
 


### PR DESCRIPTION
The current implementation of the 'utils.mlflow.tracking.get_model' function uses 'requests' to directly download the 'MLmodel' file via http. However, this is not supported by all mlflow repositories. Specifically, databricks does not support directly downloading artifacts via http, see e.g.: https://kb.databricks.com/machine-learning/mlflow-artifacts-download

This PR changes the 'get_model' function to instead use 'mlflow.artifacts.load_text'. This should be completely backwards compatible with existing mlflow repositories.

Also remove requests from setup.py since it is not directly used in the repo anymore. It is still a dependency for other packages like databricks-cli etcetera.